### PR TITLE
Feature/kanban dnd implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/react": "^0.3.2",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-collapsible": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -925,6 +927,17 @@
         "postcss-selector-parser": "^6.0.13"
       }
     },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.3.2.tgz",
+      "integrity": "sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -935,6 +948,17 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.3.2.tgz",
+      "integrity": "sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/geometry": "^0.3.2",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@dnd-kit/core": {
@@ -950,6 +974,69 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.3.2.tgz",
+      "integrity": "sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/collision": "^0.3.2",
+        "@dnd-kit/geometry": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.3.2.tgz",
+      "integrity": "sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.3.2.tgz",
+      "integrity": "sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.3.2",
+        "@dnd-kit/dom": "^0.3.2",
+        "@dnd-kit/state": "^0.3.2",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.3.2.tgz",
+      "integrity": "sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -2175,6 +2262,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
+      "integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@radix-ui/primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "collaborate-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@radix-ui/react-collapsible": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -922,6 +923,45 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare:husky": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/react": "^0.3.2",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/src/components/boards/board/board.tsx
+++ b/src/components/boards/board/board.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import { createTaskAction } from '@/app/actions/tasks'
+import { TaskListItem } from '@/components/tasks'
 import { Button, Input } from '@/components/ui'
 import { useClickOutside } from '@/hooks'
 import { useRouter } from 'next/navigation'
 import { type FormEvent, useOptimistic, useRef, useState, useTransition } from 'react'
 import styles from './styles'
 
-import { type BoardType } from '@/types/board-types'
+import type { BoardType } from '@/types/board-types'
+import type { TaskType } from '@/types/tasks-types'
 
 interface BoardProps {
   board: BoardType
@@ -25,7 +27,7 @@ export function Board({ board, workspaceUuid }: BoardProps) {
     board.tasks,
     (state, newTask: { uuid: string; title: string }) => [
       ...state,
-      newTask
+      newTask as TaskType
     ]
   )
 
@@ -58,16 +60,8 @@ export function Board({ board, workspaceUuid }: BoardProps) {
       </section>
       <section className={styles.content}>
         <div>
-          {optimisticTasks.length === 0 && (
-            <p className={styles.noTasksMessage}>No tasks yet</p>
-          )}
           {optimisticTasks.map((task) => (
-            <div
-              key={task.uuid}
-              className={`${styles.taskItem} ${task.uuid.startsWith('temp-') ? styles.taskItemPending : styles.taskItemConfirmed}`}
-            >
-              {task.title}
-            </div>
+            <TaskListItem key={task.uuid} task={task} />
           ))}
         </div>
         <div>

--- a/src/components/boards/board/board.tsx
+++ b/src/components/boards/board/board.tsx
@@ -4,12 +4,14 @@ import { createTaskAction } from '@/app/actions/tasks'
 import { TaskListItem } from '@/components/tasks'
 import { Button, Input } from '@/components/ui'
 import { useClickOutside } from '@/hooks'
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useRouter } from 'next/navigation'
-import { type FormEvent, useOptimistic, useRef, useState, useTransition } from 'react'
 import styles from './styles'
 
 import type { BoardType } from '@/types/board-types'
 import type { TaskType } from '@/types/tasks-types'
+import { type FormEvent, useOptimistic, useRef, useState, useTransition } from 'react'
 
 interface BoardProps {
   board: BoardType
@@ -24,12 +26,14 @@ export function Board({ board, workspaceUuid }: BoardProps) {
   useClickOutside(formRef, () => setShowForm(false), { enabled: showForm, detectEscapeKey: true })
 
   const [optimisticTasks, addOptimisticTask] = useOptimistic(
-    board.tasks,
+    board.tasks ?? [],
     (state, newTask: { uuid: string; title: string }) => [
       ...state,
       newTask as TaskType
     ]
   )
+
+  const { setNodeRef } = useDroppable({ id: board.uuid })
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -59,10 +63,12 @@ export function Board({ board, workspaceUuid }: BoardProps) {
         <h2 className={styles.title}>{board.name}</h2>
       </section>
       <section className={styles.content}>
-        <div>
-          {optimisticTasks.map((task) => (
-            <TaskListItem key={task.uuid} task={task} />
-          ))}
+        <div ref={setNodeRef}>
+          <SortableContext items={optimisticTasks.map((task) => task.uuid)} strategy={verticalListSortingStrategy}>
+            {optimisticTasks.map((task) => (
+              <TaskListItem key={task.uuid} task={task} />
+            ))}
+          </SortableContext>
         </div>
         <div>
           {!showForm

--- a/src/components/boards/workspace-boards/workspace-boards.tsx
+++ b/src/components/boards/workspace-boards/workspace-boards.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { Board, CreateBoard } from '@/components/boards'
+import { useKanbanDnd } from '@/hooks/useKanbanDnd'
 import { DndContext } from '@dnd-kit/core'
-import { useOptimistic } from 'react'
+import { useMemo, useOptimistic } from 'react'
 import styles from './workspace-boards.styled'
 
 import { type BoardType } from '@/types/board-types'
@@ -20,14 +21,46 @@ export function WorkspaceBoards({ initialBoards, workspaceUuid }: Props) {
       addOptimisticBoard((s) => s.filter((b) => !b.uuid?.toString().startsWith('temp-')))
       return
     }
-    addOptimisticBoard((s) => [...s, (board as BoardType)])
+    addOptimisticBoard((s) => [...s, board as BoardType])
   }
 
+  const kanbanState = useMemo(() => ({
+    columns: Object.fromEntries(
+      optimisticBoards.map(board => [
+        board.uuid,
+        { id: board.uuid, title: board.name, cardIds: board.tasks?.map(task => task.uuid) ?? [] }
+      ])
+    ),
+    cards: Object.fromEntries(
+      optimisticBoards.flatMap(board =>
+        board.tasks?.map(task => [task.uuid, { id: task.uuid, title: task.title, columnId: board.uuid }]) ?? []
+      )
+    ),
+    columnOrder: optimisticBoards.map(board => board.uuid)
+  }), [optimisticBoards])
+
+  const dnd = useKanbanDnd(kanbanState)
+
+  const taskMap = useMemo(
+    () => Object.fromEntries(
+      optimisticBoards.flatMap((board) => board.tasks?.map((task) => [task.uuid, task]) ?? [])
+    ),
+    [optimisticBoards]
+  )
+
+  const boardsWithTasks = useMemo(
+    () => optimisticBoards.map((board) => ({
+      ...board,
+      tasks: dnd.state.columns[board.uuid]?.cardIds.map((taskId) => taskMap[taskId] ?? { uuid: taskId, title: dnd.state.cards[taskId]?.title ?? '' }) ?? []
+    })),
+    [dnd.state, optimisticBoards, taskMap]
+  )
+
   return (
-    <DndContext>
+    <DndContext {...dnd}>
       <div className={styles.boardsContainer}>
         <ol className={styles.boardsList}>
-          {optimisticBoards.map((board) => (
+          {boardsWithTasks.map((board) => (
             <li key={board.uuid} className={styles.boardCard}>
               <Board board={board} workspaceUuid={workspaceUuid} />
             </li>

--- a/src/components/boards/workspace-boards/workspace-boards.tsx
+++ b/src/components/boards/workspace-boards/workspace-boards.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Board, CreateBoard } from '@/components/boards'
+import { DndContext } from '@dnd-kit/core'
 import { useOptimistic } from 'react'
 import styles from './workspace-boards.styled'
 
@@ -23,17 +24,19 @@ export function WorkspaceBoards({ initialBoards, workspaceUuid }: Props) {
   }
 
   return (
-    <div className={styles.boardsContainer}>
-      <ol className={styles.boardsList}>
-        {optimisticBoards.map((board) => (
-          <li key={board.uuid} className={styles.boardCard}>
-            <Board board={board} workspaceUuid={workspaceUuid} />
+    <DndContext>
+      <div className={styles.boardsContainer}>
+        <ol className={styles.boardsList}>
+          {optimisticBoards.map((board) => (
+            <li key={board.uuid} className={styles.boardCard}>
+              <Board board={board} workspaceUuid={workspaceUuid} />
+            </li>
+          ))}
+          <li className={styles.boardCard}>
+            <CreateBoard workSpaceUuid={workspaceUuid} onOptimisticCreate={handleOptimisticCreate} />
           </li>
-        ))}
-        <li className={styles.boardCard}>
-          <CreateBoard workSpaceUuid={workspaceUuid} onOptimisticCreate={handleOptimisticCreate} />
-        </li>
-      </ol>
-    </div>
+        </ol>
+      </div>
+    </DndContext>
   )
 }

--- a/src/components/tasks/index.ts
+++ b/src/components/tasks/index.ts
@@ -1,1 +1,1 @@
-export { TaskListItem } from "./task-list-item"
+export { TaskListItem } from './task-list-item'

--- a/src/components/tasks/index.ts
+++ b/src/components/tasks/index.ts
@@ -1,0 +1,1 @@
+export { TaskListItem } from "./task-list-item"

--- a/src/components/tasks/task-list-item/index.ts
+++ b/src/components/tasks/task-list-item/index.ts
@@ -1,1 +1,1 @@
-export { TaskListItem } from "./task-list-item"
+export { TaskListItem } from './task-list-item'

--- a/src/components/tasks/task-list-item/index.ts
+++ b/src/components/tasks/task-list-item/index.ts
@@ -1,0 +1,1 @@
+export { TaskListItem } from "./task-list-item"

--- a/src/components/tasks/task-list-item/task-list-item.styled.ts
+++ b/src/components/tasks/task-list-item/task-list-item.styled.ts
@@ -1,11 +1,11 @@
-import { css } from "~root/styled-system/css";
+import { css } from '~root/styled-system/css'
 
 export default {
   taskItem: css({
     marginBottom: '16px',
     padding: '8px',
     borderRadius: '8px',
-    cursor: 'grab',
+    cursor: 'grab'
   }),
   taskItemPending: css({
     bgColor: 'coolGray.25',

--- a/src/components/tasks/task-list-item/task-list-item.styled.ts
+++ b/src/components/tasks/task-list-item/task-list-item.styled.ts
@@ -1,0 +1,21 @@
+import { css } from "~root/styled-system/css";
+
+export default {
+  taskItem: css({
+    marginBottom: '16px',
+    padding: '8px',
+    borderRadius: '8px',
+    cursor: 'grab',
+  }),
+  taskItemPending: css({
+    bgColor: 'coolGray.25',
+    opacity: 0.7
+  }),
+  taskItemConfirmed: css({
+    bgColor: 'coolGray.50'
+  }),
+  taskItemDragging: css({
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+    cursor: 'grabbing'
+  })
+}

--- a/src/components/tasks/task-list-item/task-list-item.tsx
+++ b/src/components/tasks/task-list-item/task-list-item.tsx
@@ -1,5 +1,6 @@
-import { useDraggable } from '@dnd-kit/core'
+import { CSS } from "@dnd-kit/utilities"
 import styles from './task-list-item.styled'
+import { useSortable } from '@dnd-kit/sortable'
 
 import type { TaskType } from '@/types/tasks-types'
 
@@ -8,20 +9,26 @@ interface TaskListItemProps {
 }
 
 export function TaskListItem({ task }: TaskListItemProps) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
-    id: task.uuid
-  })
+  const {
+    setNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+  } = useSortable({ id: task.uuid, })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
   return (
     <div
       ref={setNodeRef}
+      style={style}
       {...attributes}
       {...listeners}
       className={`${styles.taskItem} ${task.uuid.startsWith('temp-') ? styles.taskItemPending : styles.taskItemConfirmed}`}
-      style={{
-        transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-        opacity: isDragging ? 0.5 : 1,
-        rotate: isDragging ? '4deg' : '0deg',
-      }}
     >
       {task.title}
     </div>

--- a/src/components/tasks/task-list-item/task-list-item.tsx
+++ b/src/components/tasks/task-list-item/task-list-item.tsx
@@ -1,4 +1,4 @@
-import { CSS } from "@dnd-kit/utilities"
+import { CSS } from '@dnd-kit/utilities'
 import styles from './task-list-item.styled'
 import { useSortable } from '@dnd-kit/sortable'
 
@@ -14,12 +14,12 @@ export function TaskListItem({ task }: TaskListItemProps) {
     attributes,
     listeners,
     transform,
-    transition,
-  } = useSortable({ id: task.uuid, })
+    transition
+  } = useSortable({ id: task.uuid })
 
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition,
+    transition
   }
 
   return (

--- a/src/components/tasks/task-list-item/task-list-item.tsx
+++ b/src/components/tasks/task-list-item/task-list-item.tsx
@@ -1,0 +1,29 @@
+import { useDraggable } from '@dnd-kit/core'
+import styles from './task-list-item.styled'
+
+import type { TaskType } from '@/types/tasks-types'
+
+interface TaskListItemProps {
+  task: TaskType
+}
+
+export function TaskListItem({ task }: TaskListItemProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: task.uuid
+  })
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`${styles.taskItem} ${task.uuid.startsWith('temp-') ? styles.taskItemPending : styles.taskItemConfirmed}`}
+      style={{
+        transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+        opacity: isDragging ? 0.5 : 1,
+        rotate: isDragging ? '4deg' : '0deg',
+      }}
+    >
+      {task.title}
+    </div>
+  )
+}

--- a/src/hooks/useKanbanDnd.ts
+++ b/src/hooks/useKanbanDnd.ts
@@ -1,3 +1,4 @@
+import { updateTaskPosition } from "@/services/tasks/tasks.client"
 import {
   DragEndEvent,
   DragOverEvent,
@@ -65,10 +66,10 @@ export function useKanbanDnd(initial: KanbanState) {
   }
 
   async function commit(activeId: string, toColumnId: string) {
+    console.log(activeId, toColumnId);
+
     try {
-      // await moveCardApi(activeId, toColumnId)
-      console.log("Here run a action");
-      
+      await updateTaskPosition(activeId, toColumnId)
     } catch {
       rollback()
     }

--- a/src/hooks/useKanbanDnd.ts
+++ b/src/hooks/useKanbanDnd.ts
@@ -1,11 +1,11 @@
-import { updateTaskPosition } from "@/services/tasks/tasks.client"
+import { updateTaskPosition } from '@/services/tasks/tasks.client'
 import {
   DragEndEvent,
   DragOverEvent,
   closestCorners
-} from "@dnd-kit/core"
-import { arrayMove } from "@dnd-kit/sortable"
-import { useRef, useState } from "react"
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import { useRef, useState } from 'react'
 
 export type KanbanState = {
   columns: Record<string, { id: string; title: string; cardIds: string[] }>
@@ -66,7 +66,7 @@ export function useKanbanDnd(initial: KanbanState) {
   }
 
   async function commit(activeId: string, toColumnId: string) {
-    console.log(activeId, toColumnId);
+    console.log(activeId, toColumnId)
 
     try {
       await updateTaskPosition(activeId, toColumnId)

--- a/src/hooks/useKanbanDnd.ts
+++ b/src/hooks/useKanbanDnd.ts
@@ -1,0 +1,111 @@
+import {
+  DragEndEvent,
+  DragOverEvent,
+  closestCorners
+} from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+import { useRef, useState } from "react"
+
+export type KanbanState = {
+  columns: Record<string, { id: string; title: string; cardIds: string[] }>
+  cards: Record<string, { id: string; title: string; columnId: string }>
+  columnOrder: string[]
+}
+
+export function useKanbanDnd(initial: KanbanState) {
+  const [state, setState] = useState(initial)
+  const snapshot = useRef<KanbanState | null>(null)
+
+  function optimisticMove(activeId: string, overId: string) {
+    setState((s) => {
+      const next = structuredClone(s)
+      const activeCard = next.cards[activeId]
+      if (!activeCard) return s
+
+      if (next.columns[overId]) {
+        const targetColumnId = overId
+        if (activeCard.columnId === targetColumnId) return s
+
+        const fromCol = next.columns[activeCard.columnId]
+        const toCol = next.columns[targetColumnId]
+        if (!fromCol || !toCol) return s
+
+        fromCol.cardIds = fromCol.cardIds.filter((id) => id !== activeId)
+        toCol.cardIds.push(activeId)
+        activeCard.columnId = targetColumnId
+        return next
+      }
+
+      const overCard = next.cards[overId]
+      if (!overCard) return s
+
+      const fromCol = next.columns[activeCard.columnId]
+      const toCol = next.columns[overCard.columnId]
+      if (!fromCol || !toCol) return s
+
+      if (activeCard.columnId === overCard.columnId) {
+        const activeIndex = fromCol.cardIds.indexOf(activeId)
+        const overIndex = fromCol.cardIds.indexOf(overId)
+        if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) return s
+
+        fromCol.cardIds = arrayMove(fromCol.cardIds, activeIndex, overIndex)
+        return next
+      }
+
+      fromCol.cardIds = fromCol.cardIds.filter((id) => id !== activeId)
+      const insertIndex = toCol.cardIds.indexOf(overId)
+      toCol.cardIds.splice(insertIndex, 0, activeId)
+      activeCard.columnId = overCard.columnId
+      return next
+    })
+  }
+
+  function rollback() {
+    if (snapshot.current) setState(snapshot.current)
+  }
+
+  async function commit(activeId: string, toColumnId: string) {
+    try {
+      // await moveCardApi(activeId, toColumnId)
+      console.log("Here run a action");
+      
+    } catch {
+      rollback()
+    }
+  }
+
+  function onDragStart() {
+    snapshot.current = structuredClone(state)
+  }
+
+  function onDragOver(e: DragOverEvent) {
+    if (!e.over) return
+
+    const activeId = e.active.id as string
+    const overId = e.over.id as string
+    if (activeId === overId) return
+
+    optimisticMove(activeId, overId)
+  }
+
+  function onDragEnd(e: DragEndEvent) {
+    if (!e.over) return
+
+    const activeId = e.active.id as string
+    const overId = e.over.id as string
+    const activeCard = state.cards[activeId]
+    if (!activeCard) return
+
+    let targetColumnId: string | null = null
+    if (state.columns[overId]) {
+      targetColumnId = overId
+    } else if (state.cards[overId]) {
+      targetColumnId = state.cards[overId].columnId
+    }
+
+    if (!targetColumnId) return
+    commit(activeId, targetColumnId)
+  }
+
+  return { state, onDragStart, onDragOver, onDragEnd, collisionDetection: closestCorners }
+}

--- a/src/services/tasks/index.ts
+++ b/src/services/tasks/index.ts
@@ -7,3 +7,14 @@ export async function createBoardTask(data: { boardUuid: string; taskTitle: stri
   })
   return response
 }
+
+export async function updateTaskPosition(taskUuid: string, boardUuid: string) {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/tasks/move-task`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ taskUuid, boardUuid })
+  })
+  return response
+}

--- a/src/services/tasks/index.ts
+++ b/src/services/tasks/index.ts
@@ -12,7 +12,7 @@ export async function updateTaskPosition(taskUuid: string, boardUuid: string) {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/tasks/move-task`, {
     method: 'PATCH',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({ taskUuid, boardUuid })
   })

--- a/src/services/tasks/tasks.client.ts
+++ b/src/services/tasks/tasks.client.ts
@@ -1,0 +1,11 @@
+export async function updateTaskPosition(taskUuid: string, boardUuid: string) {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/tasks/move-task`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    credentials: 'include',
+    body: JSON.stringify({ taskUuid, boardUuid })
+  })
+  return response
+}

--- a/src/types/board-types.d.ts
+++ b/src/types/board-types.d.ts
@@ -1,3 +1,5 @@
+import { TaskType } from "./tasks-types"
+
 export interface BoardType {
   id: number
   uuid: string

--- a/src/types/board-types.d.ts
+++ b/src/types/board-types.d.ts
@@ -1,4 +1,4 @@
-import { TaskType } from "./tasks-types"
+import { TaskType } from './tasks-types'
 
 export interface BoardType {
   id: number

--- a/src/types/tasks-types.d.ts
+++ b/src/types/tasks-types.d.ts
@@ -1,0 +1,7 @@
+export interface TaskType {
+  uuid: string
+  title: string
+  description: string
+  tags: string[]
+  createdAt: string
+}


### PR DESCRIPTION
# Kanban DnD Implementation

## Summary
Implemented drag-and-drop support for the Kanban board using `@dnd-kit`.

## What was added
- Added a centralized `useKanbanDnd` hook to manage Kanban state with columns, cards, and ordering.
- Added optimistic moves for cards:
  - moving cards across columns
  - reordering cards within the same column
- Updated `WorkspaceBoards` to wrap all boards in a single `DndContext`.
- Linked board UI state to DnD state so task movement is reflected immediately.
- Updated `Board` to act as a droppable container and added `SortableContext` for task ordering.
- Cleaned up DnD imports and module logic.

## Key files changed
- `src/hooks/useKanbanDnd.ts`
- `src/components/boards/workspace-boards/workspace-boards.tsx`
- `src/components/boards/board/board.tsx`
- `src/components/tasks/task-list-item/task-list-item.tsx`

## Benefit
This change enables a smoother Kanban experience with drag-and-drop task management and sets up a foundation for backend persistence of card moves.